### PR TITLE
Allow zero max retries

### DIFF
--- a/lib/httpx/plugins/retries.rb
+++ b/lib/httpx/plugins/retries.rb
@@ -58,8 +58,6 @@ module HTTPX
 
         def option_max_retries(value)
           num = Integer(value)
-          raise TypeError, ":max_retries must be positive" unless num.positive?
-
           num
         end
 


### PR DESCRIPTION
Hello @HoneyryderChuck,

Your work is a piece of art.

I'm not sure if there's a better way to make httpx zero retires, I tried `faraday.request :retry, max: 0`but it didn't work.

This came up while I was using the click_house gem: https://github.com/shlima/click_house/pull/49