### PR TITLE
Remove deprecated lazy option from datadog adapter

### DIFF
--- a/lib/httpx/adapters/datadog.rb
+++ b/lib/httpx/adapters/datadog.rb
@@ -147,17 +147,14 @@ module Datadog::Tracing
           else
             option :enabled do |o|
               o.default { env_to_bool("DD_TRACE_HTTPX_ENABLED", true) }
-              o.lazy
             end
 
             option :analytics_enabled do |o|
               o.default { env_to_bool(%w[DD_TRACE_HTTPX_ANALYTICS_ENABLED DD_HTTPX_ANALYTICS_ENABLED], false) }
-              o.lazy
             end
 
             option :analytics_sample_rate do |o|
               o.default { env_to_float(%w[DD_TRACE_HTTPX_ANALYTICS_SAMPLE_RATE DD_HTTPX_ANALYTICS_SAMPLE_RATE], 1.0) }
-              o.lazy
             end
           end
 
@@ -169,14 +166,12 @@ module Datadog::Tracing
                   "httpx"
                 )
               end
-              o.lazy
             end
           else
             option :service_name do |o|
               o.default do
                 ENV.fetch("DD_TRACE_HTTPX_SERVICE_NAME", "httpx")
               end
-              o.lazy
             end
           end
 


### PR DESCRIPTION
Removed `lazy` option for datadog adapter as it is now deprecated in datadog (https://github.com/DataDog/dd-trace-rb/pull/2931) and what's worse it makes httpx to throw warnings for each usage (5 warning together).

```
WARN -- ddtrace: [ddtrace] Defining an option as lazy is deprecated for removal. Options now always behave as lazy. Please remove all references to the lazy setting.
+# Non-lazy options that were previously stored as blocks are no longer supported. If you used this feature, please let us know by opening an issue on: https://github.com/datadog/dd-trace-rb/issues/new so we can better understand and support your use case. This will be enforced in the next major release.
```