### PR TITLE
Allow additional form post parameters in the oauth token request

### DIFF
--- a/lib/httpx/plugins/oauth.rb
+++ b/lib/httpx/plugins/oauth.rb
@@ -127,7 +127,7 @@ module HTTPX
           grant_type = oauth_session.grant_type
 
           headers = {}
-          form_post = { "grant_type" => grant_type, "scope" => Array(oauth_session.scope).join(" ") }.reverse_merge(oauth_session.token_endpoint_form_post).compact
+          form_post = oauth_session.token_endpoint_form_post.merge({ "grant_type" => grant_type, "scope" => Array(oauth_session.scope).join(" ") }).compact
 
           # auth
           case oauth_session.token_endpoint_auth_method

--- a/lib/httpx/plugins/oauth.rb
+++ b/lib/httpx/plugins/oauth.rb
@@ -16,7 +16,7 @@ module HTTPX
       SUPPORTED_AUTH_METHODS = %w[client_secret_basic client_secret_post].freeze
 
       class OAuthSession
-        attr_reader :grant_type, :client_id, :client_secret, :access_token, :refresh_token, :scope
+        attr_reader :grant_type, :client_id, :client_secret, :access_token, :refresh_token, :scope, :token_endpoint_form_post
 
         def initialize(
           issuer:,
@@ -28,7 +28,8 @@ module HTTPX
           token_endpoint: nil,
           response_type: nil,
           grant_type: nil,
-          token_endpoint_auth_method: nil
+          token_endpoint_auth_method: nil,
+          token_endpoint_form_post: {}
         )
           @issuer = URI(issuer)
           @client_id = client_id
@@ -44,6 +45,7 @@ module HTTPX
           @access_token = access_token
           @refresh_token = refresh_token
           @token_endpoint_auth_method = String(token_endpoint_auth_method) if token_endpoint_auth_method
+          @token_endpoint_form_post = token_endpoint_form_post.transform_keys(&:to_s)
           @grant_type = grant_type || (@refresh_token ? "refresh_token" : "client_credentials")
 
           unless @token_endpoint_auth_method.nil? || SUPPORTED_AUTH_METHODS.include?(@token_endpoint_auth_method)
@@ -125,7 +127,7 @@ module HTTPX
           grant_type = oauth_session.grant_type
 
           headers = {}
-          form_post = { "grant_type" => grant_type, "scope" => Array(oauth_session.scope).join(" ") }.compact
+          form_post = { "grant_type" => grant_type, "scope" => Array(oauth_session.scope).join(" ") }.reverse_merge(oauth_session.token_endpoint_form_post).compact
 
           # auth
           case oauth_session.token_endpoint_auth_method


### PR DESCRIPTION
We have a use case to add an "audience" parameter to the token request but this plugin provides no easy mechanism for adding additional parameters.