### PR TITLE
Include query_params in response cache key

### DIFF
--- a/lib/httpx/plugins/response_cache.rb
+++ b/lib/httpx/plugins/response_cache.rb
@@ -207,7 +207,7 @@ module HTTPX
         # returns a unique cache key as a String identifying this request
         def response_cache_key
           @response_cache_key ||= begin
-            keys = [@verb, @uri, (Transcoder::Form.encode(@query_params) if @query_params && !@query_params.empty?)]
+            keys = [@verb, @uri.merge(path)]
 
             @options.supported_vary_headers.each do |field|
               value = @headers[field]

--- a/test/support/response_cache_store_tests.rb
+++ b/test/support/response_cache_store_tests.rb
@@ -19,6 +19,9 @@ module ResponseCacheStoreTests
 
     request3 = make_request("POST", "http://store-cache/")
     assert store.get(request3).nil?
+
+    request4 = make_request("GET", "http://store-cache/", params: { "foo" => "bar" })
+    assert store.get(request4).nil?
   end
 
   def test_store_prepare_maxage


### PR DESCRIPTION
Otherwise these two requests return the same result, which is clearly wrong.

```
HTTPX.plugin(:response_cache)
client.get("https://www.google.com", params: { q: "me" })
client.get("https://www.google.com", params: { q: "you" })
```