### PR TITLE
Fix NoMethodError when closing session with stream_bidi plugin

### DIFF
--- a/lib/httpx/plugins/stream_bidi.rb
+++ b/lib/httpx/plugins/stream_bidi.rb
@@ -156,7 +156,13 @@ module HTTPX
 
         def timeout; end
 
+        def inflight?
+          !@closed
+        end
+
         def terminate
+          return if @closed
+
           @pipe_write.close
           @pipe_read.close
           @closed = true

--- a/test/support/requests/plugins/stream_bidi.rb
+++ b/test/support/requests/plugins/stream_bidi.rb
@@ -8,6 +8,12 @@ module Requests
     # https://gitlab.com/os85/httpx/wikis/Stream-Bidi
     #
     module StreamBidi
+      # https://github.com/HoneyryderChuck/httpx/issues/114
+      def test_plugin_stream_bidi_persistent_session_close
+        session = HTTPX.with(persistent: true).plugin(:stream_bidi)
+        session.close # should not raise NoMethodError: undefined method `inflight?' for Signal
+      end
+
       def test_plugin_stream_bidi_each
         start_test_servlet(Bidi, tls: false) do |server|
           uri = "#{server.origin}/"


### PR DESCRIPTION
## Summary

- Add missing `inflight?` method to `Signal` class that `Selector#terminate` expects
- Make `Signal#terminate` idempotent to handle being called multiple times

## Details

When closing a persistent session with the `stream_bidi` plugin, `Selector#terminate` calls `@selectables.reject(&:inflight?)` on all registered selectables. The `Signal` class implements the Selectable interface but was missing the `inflight?` method, causing a `NoMethodError`.

The `inflight?` method returns `!@closed` as suggested by the maintainer - indicating the Signal has work to do while it's still open.

Additionally, `terminate` is now idempotent (guards against `@closed`) to prevent `IOError: closed stream` when the method is called multiple times, which can happen due to Signal being re-registered during the close flow.

## Test plan

- [x] Added regression test `test_plugin_stream_bidi_session_close`
- [x] All existing stream_bidi tests pass

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)