### PR TITLE
fix stream_bidi callback leak causing protocol errors on retry

### DIFF
--- a/lib/httpx/plugins/stream_bidi.rb
+++ b/lib/httpx/plugins/stream_bidi.rb
@@ -280,6 +280,9 @@ module HTTPX
           case nextstate
           when :idle
             headers_sent = false
+            # Clear :body callbacks to prevent stale callbacks from previous
+            # connection attempts when retrying (fixes stream_bidi + retries interaction)
+            callbacks(:body).clear
           when :waiting_for_chunk
             return unless @state == :body
           when :body

--- a/test/support/servlets/bidi_fail_after_data.rb
+++ b/test/support/servlets/bidi_fail_after_data.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "bidi"
+
+# BidiFailAfterData is a Bidi server that fails after receiving the first DATA frame.
+# This simulates a connection failure during active bidirectional streaming,
+# triggering the retry mechanism while the client is actively sending data.
+#
+# The sequence is:
+# 1. First stream: receives client headers, sends response headers, receives first DATA, then GOAWAY
+# 2. Second stream (retry): works normally like Bidi
+class BidiFailAfterData < Bidi
+  def initialize(**)
+    @stream_count = 0
+    super
+  end
+
+  private
+
+  def handle_stream(conn, stream)
+    @stream_count += 1
+
+    if @stream_count == 1
+      # First request: send headers, wait for first data, then fail
+      stream.on(:data) do |_d|
+        # After receiving first data chunk, send GOAWAY
+        conn.goaway(:no_error)
+      end
+
+      stream.headers({
+                       ":status" => "200",
+                       "date" => Time.now.httpdate,
+                       "content-type" => "application/x-ndjson",
+                     }, end_stream: false)
+    else
+      # Subsequent requests: work normally
+      super
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes callback leak in `stream_bidi` plugin when used with `retries` plugin
- Clears `:body` callbacks when request transitions to `:idle` state

Fixes #127

## Problem

When using `stream_bidi` with `retries`, callbacks registered on the request object were not cleared when the request was reset to `:idle` state for retry. This caused stale callbacks (capturing old HTTP2 parser and stream references) to fire alongside new callbacks, resulting in corrupted HTTP/2 frames being written to the shared write buffer and causing `protocol_error` from the server.

## Solution

Clear `:body` callbacks when transitioning to `:idle` state in `RequestMethods#transition`.

Note: We intentionally do NOT reset `@closed` because:
1. If user already called `close()`, the empty end-marker chunk is in the body and will be resent correctly
2. The `end_stream?` method relies on `closed?` to set the `end_stream` flag - resetting `@closed` would cause the stream to never end

## Test plan

- [x] Verified fix with reproduction script (5 consecutive runs pass)
- [x] All existing `stream_bidi` tests pass (6/6)
- [x] `test_plugin_stream_bidi_retry_after_headers_sent` specifically tests retry behavior

🤖 Generated with [Claude Code](https://claude.ai/code)