### PR TITLE
webmock adapter emits `:response` before body chunks are written,

### DIFF
--- a/lib/httpx/adapters/webmock.rb
+++ b/lib/httpx/adapters/webmock.rb
@@ -130,12 +130,12 @@ module WebMock
             request.transition(:body)
             request.transition(:trailers)
             request.transition(:done)
+            response << mock_response.body.dup unless response.is_a?(HTTPX::ErrorResponse)
             response.finish!
             request.response = response
             request.emit_response(response)
             request_signature.headers = request.headers.to_h
 
-            response << mock_response.body.dup unless response.is_a?(HTTPX::ErrorResponse)
           elsif WebMock.net_connect_allowed?(request_signature.uri)
             if WebMock::CallbackRegistry.any_callbacks?
               request.on(:response) do |resp|


### PR DESCRIPTION
so `:callbacks` `on_response_completed` sees an empty body

In the `httpx` webmock adapter (`lib/httpx/adapters/webmock.rb`), the response body is appended **after** `request.emit_response(response)` fires. U nder the `:callbacks` plugin, `on_response_completed` callbacks fire from `request.on(:response)`, which means user code that reads `response.body` inside a `response_completed` callback sees an empty body under webmock — even though the same code works correctly against a live server.

In real `httpx` (e.g. `lib/httpx/connection/http1.rb#dispatch`, and `lib/httpx/connection.rb` near `response.finish! ; request.emit(:response, ...)`), body chunks are streamed into the response **before** `:response` is emitted.

The webmock adapter has the order reversed.