### PR TITLE
clear timer callbacks on connection close

### DIFF
--- a/lib/httpx/connection.rb
+++ b/lib/httpx/connection.rb
@@ -1121,6 +1121,7 @@ module HTTPX
 
         timer = selector.after(timeout, callback)
         request.active_timeouts << label
+        request.once(:idle) { timer.cancel }
 
         Array(finish_events).each do |event|
           # clean up request timeouts if the connection errors out

--- a/regression_tests/bug_1_7_5_test.rb
+++ b/regression_tests/bug_1_7_5_test.rb
@@ -22,7 +22,7 @@ class Bug_1_7_5_Test < Minitest::Test
     end
   end
 
-  def test_plugin_retries_request_timeoust_close_current_connection
+  def test_plugin_retries_request_timeout_close_current_connection
     pool_class = Class.new(HTTPX::Pool) do
       attr_reader :used_connections
 

--- a/regression_tests/bug_1_8_0_test.rb
+++ b/regression_tests/bug_1_8_0_test.rb
@@ -13,4 +13,57 @@ class Bug_1_8_0_Test < Minitest::Test
 
     verify_error_response(response, HTTPX::ConnectTimeoutError)
   end
+
+  def test_plugin_retries_request_timeout_cancel_timers
+    with_unreliable_server do |uri|
+      http = HTTPX.plugin(:persistent).with(timeout: { request_timeout: 10 })
+
+      100.times do |i|
+        http.get(uri).raise_for_status
+      end
+
+      selector = Thread.current.thread_variable_get(:httpx_persistent_selector_store)[http]
+
+      callback_size = selector.
+        instance_variable_get(:@timers).
+        instance_variable_get(:@intervals).
+        map { |interval| interval.instance_variable_get(:@callbacks).size }.
+        sum
+
+      assert callback_size == 0, "Expected callbacks to be clear after close connection"
+    end
+  end
+
+  private
+
+  def with_unreliable_server
+    server = TCPServer.new(0)
+
+    thread = Thread.start do
+      loop do
+        begin
+          sock = server.accept
+          line = sock.gets until line != "\r\n"
+          sock.write "HTTP/1.1 200 OK\r\n" \
+                    "Content-Length: 2\r\n\r\n" \
+                    "ok"
+          sock.close
+        end
+      rescue IOError
+        break
+      end
+    end
+
+    begin
+      yield("http://localhost:#{server.addr[1]}")
+    ensure
+      begin
+        Timeout.timeout(2) do
+          server.close rescue nil
+        end
+      rescue Timeout::Error
+        thread.kill
+      end
+    end
+  end
 end


### PR DESCRIPTION
this helps prevent a resource leak when a remote closes a persistent connection