### PR TITLE
http2: retry requests the peer never processed after a GOAWAY, regardless of method

### DIFF
--- a/lib/httpx/connection/http2.rb
+++ b/lib/httpx/connection/http2.rb
@@ -23,8 +23,15 @@ module HTTPX
     end
 
     class GoawayError < Error
-      def initialize(code = :no_error)
+      def initialize(code = :no_error, unprocessed: false)
         super(0, code)
+        @unprocessed = unprocessed
+      end
+
+      # RFC 7540 section 6.8: true when the peer is guaranteed to have never processed the
+      # associated request.
+      def unprocessed?
+        @unprocessed
       end
     end
 
@@ -432,7 +439,7 @@ module HTTPX
       send_pending
     end
 
-    def on_close(_last_frame, error, _payload)
+    def on_close(last_stream_id, error, _payload)
       is_connection_closed = @connection.closed?
       if error
         @buffer.clear if is_connection_closed
@@ -442,17 +449,30 @@ module HTTPX
             emit(:error, request, error)
           end
         else
-          ex = GoawayError.new(error)
-          ex.set_backtrace(caller)
-
-          handle_error(ex)
+          handle_goaway(last_stream_id, error)
           teardown
-
         end
       end
       return unless is_connection_closed && @streams.empty?
 
       emit(:close) if is_connection_closed
+    end
+
+    # streams above +last_stream_id+, and requests still in +@pending+ (which never got a
+    # stream id at all), are guaranteed by RFC 7540 section 6.8 to have never been processed.
+    def handle_goaway(last_stream_id, error)
+      while (req, stream = @streams.shift)
+        emit_goaway_error(req, error, stream.id > last_stream_id)
+      end
+      while (req = @pending.shift)
+        emit_goaway_error(req, error, true)
+      end
+    end
+
+    def emit_goaway_error(request, error, unprocessed)
+      ex = GoawayError.new(error, unprocessed: unprocessed)
+      ex.set_backtrace(caller)
+      emit(:error, request, ex)
     end
 
     def on_frame_sent(frame)

--- a/lib/httpx/connection/http2.rb
+++ b/lib/httpx/connection/http2.rb
@@ -46,6 +46,7 @@ module HTTPX
       @drains = {}
       @pings = []
       @streams_to_close_after_receive = []
+      @goaway_error = :no_error
       @buffer = buffer
       @handshake_completed = false
       @wait_for_handshake = @settings.key?(:wait_for_handshake) ? @settings.delete(:wait_for_handshake) : true
@@ -128,6 +129,13 @@ module HTTPX
     end
 
     def send(request, head = false)
+      # a GOAWAY (graceful or not) forbids opening new streams; this request will never be
+      # sent on this connection, so it's unconditionally safe to retry elsewhere.
+      if @connection.closed?
+        emit_goaway_error(request, @goaway_error, true)
+        return false
+      end
+
       unless can_buffer_more_requests?
         head ? @pending.unshift(request) : @pending << request
         return false
@@ -192,6 +200,7 @@ module HTTPX
 
     def can_buffer_more_requests?
       (@handshake_completed || !@wait_for_handshake) &&
+        !@connection.closed? &&
         @streams.size < @max_concurrent_requests &&
         @streams.size < @max_requests
     end
@@ -419,7 +428,9 @@ module HTTPX
       end
       send(@pending.shift) unless @pending.empty?
 
-      return unless @streams.empty? && exhausted?
+      # once a goaway leaves the connection draining, closing it once the last tracked
+      # stream finishes is not optional (no new streams can be opened on it anymore).
+      return unless @streams.empty? && (exhausted? || @connection.closed?)
 
       if @pending.empty?
         close
@@ -442,15 +453,23 @@ module HTTPX
     def on_close(last_stream_id, error, _payload)
       is_connection_closed = @connection.closed?
       if error
-        @buffer.clear if is_connection_closed
         case error
         when :http_1_1_required
+          @buffer.clear
           while (request = @pending.shift)
             emit(:error, request, error)
           end
         else
-          handle_goaway(last_stream_id, error)
-          teardown
+          # a NO_ERROR goaway with streams still open leaves the connection +closing?+
+          # (not +closed?+) until those streams finish, per RFC 7540 section 6.8 (this
+          # includes the initial phase of a graceful shutdown, sent with the maximum
+          # stream id as a sentinel, before the peer follows up with the real cutoff).
+          # only tear everything down when this goaway is the terminal one.
+          going_away = @connection.closing?
+          @buffer.clear unless going_away
+          @goaway_error = error
+          handle_goaway(last_stream_id, error, going_away)
+          teardown unless going_away
         end
       end
       return unless is_connection_closed && @streams.empty?
@@ -458,12 +477,17 @@ module HTTPX
       emit(:close) if is_connection_closed
     end
 
-    # streams above +last_stream_id+, and requests still in +@pending+ (which never got a
-    # stream id at all), are guaranteed by RFC 7540 section 6.8 to have never been processed.
-    def handle_goaway(last_stream_id, error)
-      while (req, stream = @streams.shift)
+    # streams above +last_stream_id+ are guaranteed by RFC 7540 section 6.8 to have never
+    # been processed, and are failed unconditionally; while the connection is gracefully
+    # +going_away+, streams at or below it are left alone to complete normally, since the
+    # peer promised to still act on them. requests still in +@pending+ never got a stream
+    # id at all, so the same guarantee as the above-cutoff case applies to them regardless.
+    def handle_goaway(last_stream_id, error, going_away)
+      @streams.select { |_, stream| !going_away || stream.id > last_stream_id }.each do |req, stream|
+        @streams.delete(req)
         emit_goaway_error(req, error, stream.id > last_stream_id)
       end
+
       while (req = @pending.shift)
         emit_goaway_error(req, error, true)
       end

--- a/lib/httpx/plugins/persistent.rb
+++ b/lib/httpx/plugins/persistent.rb
@@ -92,6 +92,10 @@ module HTTPX
 
             error = response.error
 
+            # a goaway error reaching this point is not unprocessed (see the check above), so it
+            # must follow the default method idempotency rules instead of being blindly retried.
+            return false if error.is_a?(Connection::HTTP2::GoawayError)
+
             reconnectable_error?(error)
           end
         end

--- a/lib/httpx/plugins/retries.rb
+++ b/lib/httpx/plugins/retries.rb
@@ -8,7 +8,9 @@ module HTTPX
     # It has a default max number of retries (see *MAX_RETRIES* and the *max_retries* option),
     # after which it will return the last response, error or not. It will **not** raise an exception.
     #
-    # It does not retry which are not considered idempotent (see *retry_change_requests* to override).
+    # It does not retry requests which are not considered idempotent (see *retry_change_requests*
+    # to override), unless the request is one the peer is guaranteed to have never processed (e.g.
+    # an HTTP/2 GOAWAY for a stream above the reported last stream id) and its body can be re-sent.
     #
     # https://gitlab.com/os85/httpx/wikis/Retries
     #
@@ -187,7 +189,7 @@ module HTTPX
         def retryable_request?(request, response, options)
           IDEMPOTENT_METHODS.include?(request.verb) ||
             options.retry_change_requests ||
-            goaway_unprocessed?(response)
+            (goaway_unprocessed?(response) && request.body.rewindable?)
         end
 
         # returns whether +response+ carries a GOAWAY error for a request the peer never processed.

--- a/lib/httpx/plugins/retries.rb
+++ b/lib/httpx/plugins/retries.rb
@@ -184,8 +184,17 @@ module HTTPX
         end
 
         # returns whether +request+ can be retried.
-        def retryable_request?(request, _, options)
-          IDEMPOTENT_METHODS.include?(request.verb) || options.retry_change_requests
+        def retryable_request?(request, response, options)
+          IDEMPOTENT_METHODS.include?(request.verb) ||
+            options.retry_change_requests ||
+            goaway_unprocessed?(response)
+        end
+
+        # returns whether +response+ carries a GOAWAY error for a request the peer never processed.
+        def goaway_unprocessed?(response)
+          response.is_a?(ErrorResponse) &&
+            response.error.is_a?(Connection::HTTP2::GoawayError) &&
+            response.error.unprocessed?
         end
 
         def retryable_response?(response, options)

--- a/lib/httpx/request/body.rb
+++ b/lib/httpx/request/body.rb
@@ -78,6 +78,11 @@ module HTTPX
       @body.rewind if @body.respond_to?(:rewind)
     end
 
+    # returns whether the body can be safely re-sent from the start on a retry.
+    def rewindable?
+      !unbounded_body? && (empty? || @body.respond_to?(:rewind))
+    end
+
     # return +true+ if the +body+ has been fully drained (or does nnot exist).
     def empty?
       return true if @body.nil?

--- a/sig/connection/http2.rbs
+++ b/sig/connection/http2.rbs
@@ -91,7 +91,11 @@ module HTTPX
 
     def on_settings: (*untyped) -> void
 
-    def on_close: (Integer last_frame, Symbol? error, String? payload) -> void
+    def on_close: (Integer last_stream_id, Symbol? error, String? payload) -> void
+
+    def handle_goaway: (Integer last_stream_id, Symbol error) -> void
+
+    def emit_goaway_error: (Request request, Symbol error, bool unprocessed) -> void
 
     def on_frame_sent: (::HTTP2::frame frame) -> void
 
@@ -116,7 +120,9 @@ module HTTPX
     end
 
     class GoawayError < Error
-      def initialize: (?Symbol code) -> void
+      def initialize: (?Symbol code, ?unprocessed: bool) -> void
+
+      def unprocessed?: () -> bool
     end
 
     class PingError < Error

--- a/sig/request/body.rbs
+++ b/sig/request/body.rbs
@@ -13,6 +13,8 @@ module HTTPX
 
     def rewind: () -> void
 
+    def rewindable?: () -> bool
+
     def empty?: () -> bool
 
     def bytesize: () -> (Integer | Float)

--- a/test/connection_http2_test.rb
+++ b/test/connection_http2_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class ConnectionHTTP2Test < Minitest::Test
+  include HTTPX
+
+  def test_goaway_marks_stream_above_last_stream_id_as_unprocessed
+    conn = build_connection
+
+    request_at = build_request
+    request_above = build_request
+
+    stream_at = add_stream(conn, request_at)
+    add_stream(conn, request_above)
+
+    errors = {}
+    conn.on(:error) { |request, error| errors[request] = error }
+
+    conn.__send__(:on_close, stream_at.id, :no_error, nil)
+
+    refute errors[request_at].unprocessed?, "stream at last_stream_id should not be unprocessed"
+    assert errors[request_above].unprocessed?, "stream above last_stream_id should be unprocessed"
+  end
+
+  def test_goaway_marks_pending_request_as_unprocessed
+    conn = build_connection
+
+    request_sent = build_request
+    request_pending = build_request
+
+    stream_sent = add_stream(conn, request_sent)
+    conn.pending << request_pending
+
+    errors = {}
+    conn.on(:error) { |request, error| errors[request] = error }
+
+    conn.__send__(:on_close, stream_sent.id, :no_error, nil)
+
+    refute errors[request_sent].unprocessed?
+    assert errors[request_pending].unprocessed?
+  end
+
+  private
+
+  def build_connection
+    options = Options.new
+    Connection::HTTP2.new(Buffer.new(options.buffer_size), options)
+  end
+
+  def build_request
+    Request.new("GET", "http://example.com/", Options.new)
+  end
+
+  def add_stream(conn, request)
+    stream = conn.instance_variable_get(:@connection).new_stream(**request.http2_stream_options)
+    conn.streams[request] = stream
+    stream
+  end
+end

--- a/test/connection_http2_test.rb
+++ b/test/connection_http2_test.rb
@@ -5,56 +5,156 @@ require_relative "test_helper"
 class ConnectionHTTP2Test < Minitest::Test
   include HTTPX
 
-  def test_goaway_marks_stream_above_last_stream_id_as_unprocessed
+  def test_goaway_terminal_marks_stream_above_last_stream_id_as_unprocessed
     conn = build_connection
 
-    request_at = build_request
-    request_above = build_request
-
+    request_at, request_above = build_requests(2)
     stream_at = add_stream(conn, request_at)
     add_stream(conn, request_above)
 
     errors = {}
     conn.on(:error) { |request, error| errors[request] = error }
 
-    conn.__send__(:on_close, stream_at.id, :no_error, nil)
+    send_goaway(conn, last_stream: stream_at.id, error: :internal_error)
 
     refute errors[request_at].unprocessed?, "stream at last_stream_id should not be unprocessed"
     assert errors[request_above].unprocessed?, "stream above last_stream_id should be unprocessed"
+    assert conn.streams.empty?, "a non-graceful goaway should tear down every tracked stream"
   end
 
-  def test_goaway_marks_pending_request_as_unprocessed
+  def test_goaway_terminal_marks_pending_request_as_unprocessed
     conn = build_connection
 
-    request_sent = build_request
-    request_pending = build_request
-
+    request_sent, request_pending = build_requests(2)
     stream_sent = add_stream(conn, request_sent)
     conn.pending << request_pending
 
     errors = {}
     conn.on(:error) { |request, error| errors[request] = error }
 
-    conn.__send__(:on_close, stream_sent.id, :no_error, nil)
+    send_goaway(conn, last_stream: stream_sent.id, error: :internal_error)
 
     refute errors[request_sent].unprocessed?
     assert errors[request_pending].unprocessed?
+  end
+
+  def test_goaway_graceful_leaves_streams_at_or_below_cutoff_alone
+    conn = build_connection
+
+    request_at, request_above = build_requests(2)
+    add_stream(conn, request_at)
+    add_stream(conn, request_above)
+
+    errors = {}
+    conn.on(:error) { |request, error| errors[request] = error }
+
+    # the RFC 7540 section 6.8 initial phase of a graceful shutdown: the maximum stream id
+    # is used as a sentinel, so nothing currently open is "above" it.
+    send_goaway(conn, last_stream: ::HTTP2::Framer::MAX_STREAM_ID, error: :no_error)
+
+    assert conn.instance_variable_get(:@connection).closing?, "connection should be gracefully closing"
+    assert errors.empty?, "no in-flight stream should be failed by a graceful goaway"
+    assert conn.streams.key?(request_at)
+    assert conn.streams.key?(request_above)
+  end
+
+  def test_goaway_graceful_fails_pending_request_immediately
+    conn = build_connection
+
+    request_sent, request_pending = build_requests(2)
+    add_stream(conn, request_sent)
+    conn.pending << request_pending
+
+    errors = {}
+    conn.on(:error) { |request, error| errors[request] = error }
+
+    send_goaway(conn, last_stream: ::HTTP2::Framer::MAX_STREAM_ID, error: :no_error)
+
+    assert conn.streams.key?(request_sent), "in-flight stream should be left alone"
+    assert errors[request_pending].unprocessed?, "a request that never got a stream id is always unprocessed"
+    assert conn.pending.empty?
+  end
+
+  def test_goaway_rejects_new_requests_after_going_away
+    conn = build_connection
+    add_stream(conn, build_request)
+
+    send_goaway(conn, last_stream: ::HTTP2::Framer::MAX_STREAM_ID, error: :no_error)
+
+    new_request = build_request
+    errors = {}
+    conn.on(:error) { |request, error| errors[request] = error }
+
+    refute conn.send(new_request), "no new stream should be opened once a goaway was received"
+
+    assert errors[new_request].unprocessed?
+    refute conn.pending.include?(new_request), "the request should be failed, not queued forever"
+  end
+
+  def test_goaway_second_frame_narrows_cutoff_for_remaining_streams
+    conn = build_connection
+
+    request_below, request_above = build_requests(2)
+    stream_below = add_stream(conn, request_below)
+    add_stream(conn, request_above)
+
+    send_goaway(conn, last_stream: ::HTTP2::Framer::MAX_STREAM_ID, error: :no_error)
+
+    errors = {}
+    conn.on(:error) { |request, error| errors[request] = error }
+
+    # the definitive follow-up goaway, per RFC 7540 section 6.8.
+    send_goaway(conn, last_stream: stream_below.id, error: :no_error)
+
+    assert conn.streams.key?(request_below), "stream at the definitive cutoff should still be left alone"
+    assert errors[request_above].unprocessed?, "stream above the definitive cutoff should now be failed"
+  end
+
+  def test_goaway_graceful_shutdown_finalizes_once_streams_complete
+    conn = build_connection
+
+    request_below, request_above = build_requests(2)
+    stream_below = add_stream(conn, request_below)
+    stream_above = add_stream(conn, request_above)
+
+    send_goaway(conn, last_stream: ::HTTP2::Framer::MAX_STREAM_ID, error: :no_error)
+
+    closed = false
+    conn.on(:close) { closed = true }
+
+    conn.__send__(:on_stream_close, stream_below, request_below, nil)
+    refute closed, "connection should stay open while a tracked stream is still live"
+
+    conn.__send__(:on_stream_close, stream_above, request_above, nil)
+    assert closed, "connection should finalize once every tracked stream has completed"
   end
 
   private
 
   def build_connection
     options = Options.new
-    Connection::HTTP2.new(Buffer.new(options.buffer_size), options)
+    conn = Connection::HTTP2.new(Buffer.new(options.buffer_size), options)
+    # the underlying http-2 gem requires the first received frame to be SETTINGS.
+    conn << ::HTTP2::Framer.new.generate(type: :settings, stream: 0, payload: [])
+    conn
   end
 
   def build_request
-    Request.new("GET", "http://example.com/", Options.new)
+    Request.new("POST", "http://example.com/", Options.new, body: "abc")
+  end
+
+  def build_requests(size)
+    Array.new(size) { build_request }
   end
 
   def add_stream(conn, request)
     stream = conn.instance_variable_get(:@connection).new_stream(**request.http2_stream_options)
     conn.streams[request] = stream
     stream
+  end
+
+  def send_goaway(conn, last_stream:, error:)
+    frame = ::HTTP2::Framer.new.generate(type: :goaway, stream: 0, last_stream: last_stream, error: error, payload: nil)
+    conn << frame
   end
 end

--- a/test/support/requests/plugins/persistent.rb
+++ b/test/support/requests/plugins/persistent.rb
@@ -34,6 +34,35 @@ module Requests
         assert options.persistent
       end
 
+      def test_plugin_persistent_retries_change_request_on_unprocessed_goaway
+        session = HTTPX.plugin(:persistent)
+        request = session.build_request("POST", "http://example.com/")
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: true)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        assert session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request unprocessed by the peer to be retryable"
+      end
+
+      def test_plugin_persistent_does_not_retry_change_request_on_processed_goaway
+        session = HTTPX.plugin(:persistent)
+        request = session.build_request("POST", "http://example.com/")
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: false)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        refute session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request possibly processed by the peer to follow idempotency rules"
+      end
+
+      def test_plugin_persistent_still_retries_change_request_on_reconnectable_errors
+        session = HTTPX.plugin(:persistent)
+        request = session.build_request("POST", "http://example.com/")
+        response = HTTPX::ErrorResponse.new(request, EOFError.new)
+
+        assert session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request to still be retried for other reconnectable errors"
+      end
+
       def test_plugin_persistent_does_not_retry_timeout_requests
         before_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
         persistent_session = HTTPX

--- a/test/support/requests/plugins/retries.rb
+++ b/test/support/requests/plugins/retries.rb
@@ -45,6 +45,26 @@ module Requests
         assert retries_session.calls == 3, "expected request to be retried 3 times (was #{retries_session.calls})"
       end
 
+      def test_plugin_retries_unprocessed_goaway_change_request
+        session = HTTPX.plugin(:retries)
+        request = session.build_request("POST", "http://example.com/")
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: true)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        assert session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request unprocessed by the peer to be retryable"
+      end
+
+      def test_plugin_retries_processed_goaway_change_request
+        session = HTTPX.plugin(:retries)
+        request = session.build_request("POST", "http://example.com/")
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: false)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        refute session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request possibly processed by the peer to follow idempotency rules"
+      end
+
       def test_plugin_retries_multi_request
         retries_session = HTTPX
                           .plugin(RequestInspector)

--- a/test/support/requests/plugins/retries.rb
+++ b/test/support/requests/plugins/retries.rb
@@ -65,6 +65,48 @@ module Requests
                "expected a POST request possibly processed by the peer to follow idempotency rules"
       end
 
+      def test_plugin_retries_unprocessed_goaway_change_request_with_rewindable_body
+        session = HTTPX.plugin(:retries)
+        request = session.build_request("POST", "http://example.com/", body: StringIO.new("abc"))
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: true)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        assert session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request with a rewindable body to be retryable"
+      end
+
+      def test_plugin_retries_unprocessed_goaway_change_request_with_unrewindable_body
+        session = HTTPX.plugin(:retries)
+        body = Object.new
+        def body.each
+          yield "abc"
+        end
+
+        def body.bytesize
+          3
+        end
+        request = session.build_request("POST", "http://example.com/", body: body)
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: true)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        refute session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request with a body that cannot be re-sent not to be retried automatically"
+      end
+
+      def test_plugin_retries_unprocessed_goaway_change_request_with_unbounded_body
+        session = HTTPX.plugin(:retries)
+        request = session.build_request(
+          "POST", "http://example.com/",
+          body: StringIO.new("abc"),
+          headers: { "transfer-encoding" => "chunked" }
+        )
+        error = HTTPX::Connection::HTTP2::GoawayError.new(:no_error, unprocessed: true)
+        response = HTTPX::ErrorResponse.new(request, error)
+
+        refute session.send(:retryable_request?, request, response, request.options),
+               "expected a POST request with an unbounded body not to be retried automatically"
+      end
+
       def test_plugin_retries_multi_request
         retries_session = HTTPX
                           .plugin(RequestInspector)

--- a/test/support/servlets/bidi_fail_after_data.rb
+++ b/test/support/servlets/bidi_fail_after_data.rb
@@ -23,8 +23,11 @@ class BidiFailAfterData < Bidi
     if @stream_count == 1
       # First request: send headers, wait for first data, then fail
       stream.on(:data) do |_d|
-        # After receiving first data chunk, send GOAWAY
-        conn.goaway(:no_error)
+        # After receiving first data chunk, send GOAWAY. a real error code is used because
+        # :no_error on a stream the server has no intention of ever finishing (no END_STREAM
+        # was sent) is not a graceful goaway, and httpx now (correctly) treats a genuine
+        # graceful goaway as "leave streams at or below last_stream_id alone to complete".
+        conn.goaway(:internal_error)
       end
 
       stream.headers({

--- a/test/support/servlets/bidi_fail_once.rb
+++ b/test/support/servlets/bidi_fail_once.rb
@@ -28,8 +28,11 @@ class BidiFailOnce < Bidi
                        "date" => Time.now.httpdate,
                        "content-type" => "application/x-ndjson",
                      }, end_stream: false)
-      # Send GOAWAY to trigger retry on client side
-      conn.goaway(:no_error)
+      # Send GOAWAY to trigger retry on client side. a real error code is used because
+      # :no_error on a stream the server has no intention of ever finishing (no END_STREAM
+      # was sent) is not a graceful goaway, and httpx now (correctly) treats a genuine
+      # graceful goaway as "leave streams at or below last_stream_id alone to complete".
+      conn.goaway(:internal_error)
     else
       # Subsequent requests: work normally
       super

--- a/test/support/servlets/keep_alive.rb
+++ b/test/support/servlets/keep_alive.rb
@@ -57,7 +57,11 @@ class KeepAlivePongThenGoawayServer < TestHTTP2Server
   def handle_stream(conn, stream)
     # responds once, then closes the connection
     if @sent[conn]
-      conn.goaway
+      # a real error code (rather than the default :no_error) is what actually models an
+      # abrupt connection failure: :no_error on a stream the server has no intention of ever
+      # finishing is not a graceful goaway, and httpx now (correctly) treats a genuine
+      # graceful goaway as "leave streams at or below last_stream_id alone to complete".
+      conn.goaway(:internal_error)
       @sent[conn] = false
     else
       super


### PR DESCRIPTION
## Problem

`Connection::HTTP2#on_close` receives the GOAWAY frame's `last_stream_id` but
discards it (the parameter was named `_last_frame` and never read), and fails
every open and pending request identically with a single shared exception.

Per RFC 7540 §6.8, a stream whose id is greater than the GOAWAY's
`last_stream_id` is guaranteed by the peer to have never been processed, and
is therefore safe to retry on a new connection regardless of HTTP method
(including non-idempotent ones like POST). A stream at or below it carries no
such guarantee. Requests still queued in `@pending` never got a stream id at
all, so the same "never processed" guarantee applies to them unconditionally.

None of this distinction survived to the `:retries`/`:persistent` plugins,
which could only fall back to a cruder, protocol-blind heuristic (method
idempotency, or a blanket "any reconnectable error is retryable" rule).

## Changes

- `Connection::HTTP2::GoawayError` gains `#unprocessed?`. `on_close` now marks
  each failing request based on its stream id vs. `last_stream_id`, and the
  `:retries` plugin retries an unprocessed request regardless of method.
- The connection now respects the GOAWAY's graceful two-phase shutdown (RFC
  7540 §6.8): a `:no_error` goaway that leaves the connection `closing?`
  (rather than `closed?`) no longer tears down every in-flight stream — only
  ones above `last_stream_id` fail immediately; the rest are left to complete
  normally, and a follow-up goaway narrows the cutoff further. New sends are
  rejected outright once any goaway is received, instead of sitting forever
  in `@pending` on a connection that can never flush them.
- `Request::Body#rewindable?` gates the new automatic retry: an unprocessed
  goaway is only retried without user opt-in if the request's body can
  actually be re-sent from the start. Without this, a non-rewindable body
  would silently replay as empty/truncated under the original
  `Content-Length`.
- `:persistent`'s `retryable_request?` no longer blanket-retries a
  non-idempotent request for *any* goaway — only for one the peer guarantees
  was never processed. A goaway that isn't unprocessed now follows normal
  idempotency rules, same as everywhere else.

## Behavior changes to flag for review

- **`:persistent` users**: a non-idempotent request that previously got
  blindly retried on *any* `GoawayError` will no longer be retried if that
  request's stream was at or below the peer's reported `last_stream_id`.
  Requests genuinely unprocessed by the peer, and all other reconnectable
  errors (`EOFError`, `ECONNRESET`, etc.), are unaffected.
- A GOAWAY that leaves the connection gracefully `closing?` no longer fails
  in-flight streams immediately — they're subject to whatever timeout the
  caller configured (or none, same as any other slow/silent server), rather
  than getting an eager, synthetic `GoawayError`.
- Three test servlets modeled "abrupt connection failure" with a `:no_error`
  goaway on a stream they never intended to finish; that's no longer
  distinguishable from a genuine graceful shutdown, so they now send a real
  error code, which is what they were actually simulating.

## Test plan

- New unit tests drive real GOAWAY frames through the underlying `http-2`
  gem (`test/connection_http2_test.rb`) covering: stream above/at/below
  `last_stream_id`, pending requests, the graceful two-phase shutdown, a
  rejected new send after going away, and connection finalization once a
  graceful drain completes.
- New plugin-level tests for `:retries`/`:persistent` cover the
  unprocessed/processed goaway distinction and the rewindability gate
  (rewindable body, unrewindable body, unbounded/chunked body).
- Existing GOAWAY-dependent tests updated where their fixtures relied on the
  old immediate-teardown behavior; all pass unchanged otherwise.
- Full local (non-network) test suite run clean against this branch and
  diffed against an unmodified `master` run for comparison — no regressions.